### PR TITLE
chore(npm): get the package json nice and ready for claiming the npm landscape

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "karma start --single-run"
   },
   "author": "Merrick Christensen <merrick.christensen@gmail.com>",
-  "license": "BSD-2-Clause",
+  "license": "Apache License 2.0",
   "devDependencies": {
     "pipe": "git://github.com/angular/pipe#assert"
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
-  "name": "Diary.js",
-  "version": "0.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "diary",
+  "version": "0.0.1",
+  "description": "A flexible logging and profiling library for JavaScript.",
+  "main": "src/diary.js",
+  "homepage": "https://github.com/angular/diary.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/angular/diary.js.git"
   },
-  "author": "",
+  "bugs": {
+    "url": "https://github.com/angular/diary.js/issues"
+  },
+  "scripts": {
+    "test": "karma start --single-run"
+  },
+  "author": "Merrick Christensen <merrick.christensen@gmail.com>",
   "license": "BSD-2-Clause",
   "devDependencies": {
     "pipe": "git://github.com/angular/pipe#assert"


### PR DESCRIPTION
Simply bringing the package.json file to a reasonable state so we can publish to npm.
