### PR TITLE
feature(time): implement start property for profiling end and start times of messages

### DIFF
--- a/src/guid.js
+++ b/src/guid.js
@@ -1,0 +1,7 @@
+var counter = 0;
+
+function next() {
+  return ++counter;
+}
+
+export default next;

--- a/test/diary.spec.js
+++ b/test/diary.spec.js
@@ -17,20 +17,22 @@ describe('Diary', () => {
     logger.log('info', 'feature', 'ahoy');
 
     expect(reporter.receive).toHaveBeenCalledWith({
+      guid: jasmine.any(Number),
       level: 'info',
       group: 'feature', 
-      message: 'ahoy'
+      message: 'ahoy',
+      timestamp: jasmine.any(Number)
     });
   });
 
   it('should log my info', () => {
     logger.info('my test message');
 
-    expect(reporter.receive).toHaveBeenCalledWith({
+    expect(reporter.receive).toHaveBeenCalledWith(jasmine.objectContaining({
       level: 'info',
       group: 'feature',
       message: 'my test message'
-    });
+    }));
   });
 
   it('should only send events for info', () => {
@@ -45,11 +47,11 @@ describe('Diary', () => {
     logger.info('a info message');
     logger.warn('a warn message');
 
-    expect(featureReporter.receive).toHaveBeenCalledWith({
+    expect(featureReporter.receive).toHaveBeenCalledWith(jasmine.objectContaining({
       level: 'info', 
       group: 'feature',
       message: 'a info message'
-    });
+    }));
     expect(featureReporter.receive.calls.count()).toEqual(1);
   });
 
@@ -87,17 +89,17 @@ describe('Diary', () => {
     logger.info('a info message');
     logger.warn('a warn message');
 
-    expect(universal.receive).toHaveBeenCalledWith({
+    expect(universal.receive).toHaveBeenCalledWith(jasmine.objectContaining({
       level: 'info',
       group: 'feature',
       message: 'a info message'
-    });
+    }));
 
-    expect(universal.receive).toHaveBeenCalledWith({
+    expect(universal.receive).toHaveBeenCalledWith(jasmine.objectContaining({
       level: 'warn',
       group: 'feature',
       message: 'a warn message'
-    });
+    }));
 
   });
 
@@ -117,7 +119,46 @@ describe('Diary', () => {
     httpLogger.info('hello');
     logger.info('global');
     expect(http.receive.calls.count()).toEqual(1);
-    expect(http.receive).toHaveBeenCalledWith({ level: 'info', group: 'http', message: 'hello' });
+    expect(http.receive).toHaveBeenCalledWith(jasmine.objectContaining({ level: 'info', group: 'http', message: 'hello' }));
+
+  });
+
+  describe('time', () => {
+
+    it('should return the same instance', () => {
+      expect(logger).toBe(logger.start);
+    });
+
+    it('should return a function to invoke on done', () => {
+      var end = logger.start.info('starting the time test');
+      expect(end).toBeDefined();
+    });
+
+    it('should send a log message when the timer is started', () => {
+      logger.start.info('starting the time test');
+      expect(reporter.receive.calls.count()).toEqual(1);
+    });
+
+    it('the callback should invoke another log', () => {
+      var end = logger.start.info('starting');
+      end('ending');
+      expect(reporter.receive).toHaveBeenCalledWith(jasmine.objectContaining({
+        level: 'info', 
+        group: 'feature', 
+        message: 'ending'
+      }));
+    });
+
+    it('the end log should reference the message it is ending', () => {
+      var done = logger.start.info('starting');
+      done('ending');
+
+      var start =  reporter.receive.calls.argsFor(0)[0];
+      var end  =  reporter.receive.calls.argsFor(1)[0];
+
+      expect(end.endOf).toBeDefined()
+      expect(end.endOf).toEqual(start.guid);
+    });
 
   });
   


### PR DESCRIPTION
# Work in Progress
- [x] Implement API
- [ ] Implement ConsoleReporter to support timestamps
- [ ] Code Review

This branch is the beginnings of profiling...

``` javascript
let end = logger.start.info('start some pretty hardcore work');
// All this crazy work.
end('woah, that was tiring.');
```

This would log out two messages from core: 

``` javascript
// On first call
{
  level: 'info',
  group: 'feature',
  message: 'start some pretty hardcore work',
  timestamp: 1395002162444,
  guid: 1
}

// on end call
{
  level: 'info',
  group: 'feature',
  message: 'woah, that was tiring.',
  timestamp: 1395002162448,
  guid: 2,
  endOf: 1
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/diary.js/6)

<!-- Reviewable:end -->
